### PR TITLE
Fix call to `create_async_skadnetwork_raw_report`

### DIFF
--- a/singular_api_client/singular_client.py
+++ b/singular_api_client/singular_client.py
@@ -125,7 +125,7 @@ class SingularClient(object):
         """
 
         query_dict = self._build_reporting_query(start_date, end_date, format, dimensions, metrics,
-                                                 None, None, None, app,
+                                                 [], None, None, app,
                                                  source, None, time_breakdown, country_code_format,
                                                  filters, **kwargs)
 


### PR DESCRIPTION
As-is, the `create_async_skadnetwork_raw_report` method does not function, as the call to `_build_reporting_query` assumes `discrepancy_metrics` is iterable and that value is always `None` for the SkAdNetwork reporting.